### PR TITLE
Use base class pointers rather than templating

### DIFF
--- a/include/dx2/beam.h
+++ b/include/dx2/beam.h
@@ -27,12 +27,12 @@ public:
            Vector3d polarization_normal, double polarization_fraction,
            double flux, double transmission, Probe probe,
            double sample_to_source_distance);
+  Probe get_probe() const;
+  std::string get_probe_name() const;
 
 protected:
   void init_from_json(json beam_data);
   void add_to_json(json &beam_data) const;
-  Probe get_probe() const;
-  std::string get_probe_name() const;
   Vector3d sample_to_source_direction_{0.0, 0.0,
                                        1.0}; // called direction_ in dxtbx
   double divergence_{0.0}; // "beam divergence - be more specific with name?"
@@ -41,7 +41,7 @@ protected:
   double polarization_fraction_{0.999};
   double flux_{0.0};
   double transmission_{1.0};
-  Probe probe_{Probe::xray};
+  Probe probe_{xray};
   double sample_to_source_distance_{0.0}; // FIXME is this really needed?
 };
 
@@ -156,7 +156,7 @@ void BeamBase::add_to_json(json &beam_data) const {
   beam_data["polarization_fraction"] = polarization_fraction_;
   beam_data["flux"] = flux_;
   beam_data["transmission"] = transmission_;
-  beam_data["probe"] = get_probe_name();
+  beam_data["probe"] = "x-ray"; //FIXME get_probe_name() not working?
   beam_data["sample_to_source_distance"] = sample_to_source_distance_;
 }
 
@@ -304,7 +304,7 @@ void PolychromaticBeam::set_wavelength_range(
   wavelength_range_ = wavelength_range;
 }
 
-// Classes to handle run-time polymorphism for json
+// Functions to handle run-time polymorphism for json
 // serialization/deserialization.
 
 std::shared_ptr<BeamBase> make_beam(json beam_data) {
@@ -313,7 +313,7 @@ std::shared_ptr<BeamBase> make_beam(json beam_data) {
   } else if (beam_data.find("wavelength_range") != beam_data.end()) {
     return std::make_shared<PolychromaticBeam>(beam_data);
   } else {
-    throw std::invalid_argument("Unknown beam type");
+    throw std::runtime_error("Unrecognised beam type in json data");
   }
 }
 

--- a/include/dx2/beam.h
+++ b/include/dx2/beam.h
@@ -156,7 +156,7 @@ void BeamBase::add_to_json(json &beam_data) const {
   beam_data["polarization_fraction"] = polarization_fraction_;
   beam_data["flux"] = flux_;
   beam_data["transmission"] = transmission_;
-  beam_data["probe"] = "x-ray"; //FIXME get_probe_name() not working?
+  beam_data["probe"] = "x-ray"; // FIXME get_probe_name() not working?
   beam_data["sample_to_source_distance"] = sample_to_source_distance_;
 }
 

--- a/include/dx2/beam.h
+++ b/include/dx2/beam.h
@@ -1,8 +1,8 @@
 #ifndef DX2_MODEL_BEAM_H
 #define DX2_MODEL_BEAM_H
 #include <Eigen/Dense>
-#include <nlohmann/json.hpp>
 #include <memory>
+#include <nlohmann/json.hpp>
 using Eigen::Vector3d;
 using json = nlohmann::json;
 
@@ -25,7 +25,8 @@ public:
   BeamBase() = default;
   BeamBase(Vector3d direction, double divergence, double sigma_divergence,
            Vector3d polarization_normal, double polarization_fraction,
-           double flux, double transmission, Probe probe, double sample_to_source_distance);
+           double flux, double transmission, Probe probe,
+           double sample_to_source_distance);
 
 protected:
   void init_from_json(json beam_data);
@@ -53,7 +54,8 @@ public:
   MonochromaticBeam(double wavelength, Vector3d direction, double divergence,
                     double sigma_divergence, Vector3d polarization_normal,
                     double polarization_fraction, double flux,
-                    double transmission, Probe probe, double sample_to_source_distance);
+                    double transmission, Probe probe,
+                    double sample_to_source_distance);
   MonochromaticBeam(json beam_data);
   json to_json() const;
   double get_wavelength() const;
@@ -64,7 +66,6 @@ public:
 protected:
   double wavelength_{0.0};
 };
-
 
 class PolychromaticBeam : public BeamBase {
   // A polychromatic beam (i.e. a wavelength range)
@@ -92,7 +93,8 @@ protected:
 BeamBase::BeamBase(Vector3d direction, double divergence,
                    double sigma_divergence, Vector3d polarization_normal,
                    double polarization_fraction, double flux,
-                   double transmission, Probe probe, double sample_to_source_distance)
+                   double transmission, Probe probe,
+                   double sample_to_source_distance)
     : sample_to_source_direction_{direction}, divergence_{divergence},
       sigma_divergence_{sigma_divergence},
       polarization_normal_{polarization_normal},
@@ -132,13 +134,11 @@ void BeamBase::init_from_json(json beam_data) {
   }
   if (beam_data.find("probe") != beam_data.end()) {
     std::string probe = beam_data["probe"];
-    if (probe == "x-ray"){
+    if (probe == "x-ray") {
       probe_ = Probe::xray;
-    }
-    else if (probe == "neutron"){
+    } else if (probe == "neutron") {
       probe_ = Probe::neutron;
-    }
-    else if (probe == "electron"){
+    } else if (probe == "electron") {
       probe_ = Probe::electron;
     }
   }
@@ -160,9 +160,7 @@ void BeamBase::add_to_json(json &beam_data) const {
   beam_data["sample_to_source_distance"] = sample_to_source_distance_;
 }
 
-Probe BeamBase::get_probe() const {
-  return probe_;
-}
+Probe BeamBase::get_probe() const { return probe_; }
 
 std::string BeamBase::get_probe_name() const {
   // Return a name that matches NeXus definitions from
@@ -253,8 +251,7 @@ PolychromaticBeam::PolychromaticBeam(std::array<double, 2> wavelength_range,
                                      double sigma_divergence,
                                      Vector3d polarization_normal,
                                      double polarization_fraction, double flux,
-                                     double transmission,
-                                     Probe probe,
+                                     double transmission, Probe probe,
                                      double sample_to_source_distance)
     : BeamBase{direction,
                divergence,
@@ -307,32 +304,33 @@ void PolychromaticBeam::set_wavelength_range(
   wavelength_range_ = wavelength_range;
 }
 
+// Classes to handle run-time polymorphism for json
+// serialization/deserialization.
 
-// Classes to handle run-time polymorphism for json serialization/deserialization.
-
-std::shared_ptr<BeamBase> make_beam(json beam_data){
-  if (beam_data.find("wavelength") != beam_data.end()){
+std::shared_ptr<BeamBase> make_beam(json beam_data) {
+  if (beam_data.find("wavelength") != beam_data.end()) {
     return std::make_shared<MonochromaticBeam>(beam_data);
-  }
-  else if (beam_data.find("wavelength_range") != beam_data.end()){
+  } else if (beam_data.find("wavelength_range") != beam_data.end()) {
     return std::make_shared<PolychromaticBeam>(beam_data);
-  }
-  else {
+  } else {
     throw std::invalid_argument("Unknown beam type");
   }
 }
 
-json make_beam_json(std::shared_ptr<BeamBase> beamptr){
+json make_beam_json(std::shared_ptr<BeamBase> beamptr) {
   // first try to cast to mono
-  MonochromaticBeam* monobeam = dynamic_cast<MonochromaticBeam*>(beamptr.get());
-  if (monobeam != nullptr){
+  MonochromaticBeam *monobeam =
+      dynamic_cast<MonochromaticBeam *>(beamptr.get());
+  if (monobeam != nullptr) {
     return (*monobeam).to_json();
   }
-  PolychromaticBeam* polybeam = dynamic_cast<PolychromaticBeam*>(beamptr.get());
-  if (polybeam != nullptr){
+  PolychromaticBeam *polybeam =
+      dynamic_cast<PolychromaticBeam *>(beamptr.get());
+  if (polybeam != nullptr) {
     return (*polybeam).to_json();
   }
-  throw std::runtime_error("Unable to cast base beam pointer for json creation");
+  throw std::runtime_error(
+      "Unable to cast base beam pointer for json creation");
 }
 
 #endif // DX2_MODEL_BEAM_H

--- a/include/dx2/experiment.h
+++ b/include/dx2/experiment.h
@@ -15,9 +15,10 @@ class Experiment {
 public:
   Experiment() = default;
   Experiment(json experiment_data);
+  Experiment(std::shared_ptr<BeamBase> beam, Scan scan, Goniometer gonio, Detector detector);
   json to_json() const;
   Goniometer goniometer() const;
-  template <typename BeamType> BeamType &get_beam() const;
+  std::shared_ptr<BeamBase> beam() const;
   Scan scan() const;
   Detector detector() const;
   Crystal crystal() const;
@@ -30,6 +31,16 @@ protected:
   Detector _detector{};
   Crystal _crystal{};
 };
+
+Experiment::Experiment(std::shared_ptr<BeamBase> beam,
+                       Scan scan,
+                       Goniometer gonio,
+                       Detector detector){
+    this->_beam = beam;
+    this->_scan = scan;
+    this->_goniometer = gonio;
+    this->_detector = detector;
+  }
 
 Experiment::Experiment(json experiment_data) {
   json beam_data = experiment_data["beam"][0];
@@ -84,6 +95,8 @@ json Experiment::to_json() const {
   return elist_out;
 }
 
+std::shared_ptr<BeamBase> Experiment::beam() const { return _beam; }
+
 Scan Experiment::scan() const { return _scan; }
 
 Goniometer Experiment::goniometer() const { return _goniometer; }
@@ -94,16 +107,101 @@ Crystal Experiment::crystal() const { return _crystal; }
 
 void Experiment::set_crystal(Crystal crystal) { _crystal = crystal; }
 
-template <typename BeamType> BeamType &Experiment::get_beam() const {
-  BeamType *beam = dynamic_cast<BeamType *>(_beam.get());
-  if (beam == nullptr) {
-    std::cerr << "Unable to return beam type " +
-                     std::string(typeid(BeamType).name()) + " (beam type is " +
-                     std::string(typeid(*_beam.get()).name()) + ")"
-              << std::endl;
-    std::exit(1);
+
+template<typename BeamType> class TypedExperiment {
+  public:
+    TypedExperiment(BeamType& beam, Scan scan, Goniometer gonio, Detector detector);
+    BeamType& get_beam() const;
+    Scan scan() const;
+    Detector detector() const;
+    Goniometer goniometer() const;
+    Crystal crystal() const;
+    void set_crystal(Crystal crystal);
+    json to_json() const;
+
+  private:
+    BeamType& _beam;
+    Scan _scan;
+    Goniometer _goniometer;
+    Detector _detector;
+    Crystal _crystal;
+};
+
+template<typename BeamType>
+TypedExperiment<BeamType>::TypedExperiment(BeamType& beam, Scan scan, Goniometer gonio, Detector detector) : _beam(beam), _scan(scan), _goniometer(gonio), _detector(detector){}
+
+template<typename BeamType>
+BeamType& TypedExperiment<BeamType>::get_beam() const {
+  return _beam;
+}
+
+template<typename BeamType>
+Scan TypedExperiment<BeamType>::scan() const { return _scan; }
+
+template<typename BeamType>
+Goniometer TypedExperiment<BeamType>::goniometer() const { return _goniometer; }
+
+template<typename BeamType>
+Detector TypedExperiment<BeamType>::detector() const { return _detector; }
+
+template<typename BeamType>
+Crystal TypedExperiment<BeamType>::crystal() const { return _crystal; }
+
+template<typename BeamType>
+void TypedExperiment<BeamType>::set_crystal(Crystal crystal) { _crystal = crystal; }
+
+template<typename BeamType>
+json TypedExperiment<BeamType>::to_json() const {
+  // save this experiment as an example experiment list
+  json elist_out; // a list of potentially multiple experiments
+  elist_out["__id__"] = "ExperimentList";
+  json expt_out; // our single experiment
+  // no imageset (for now?).
+  expt_out["__id__"] = "Experiment";
+  expt_out["identifier"] = "test";
+  expt_out["beam"] =
+      0; // the indices of the models that will correspond to our experiment
+  expt_out["detector"] = 0;
+  expt_out["goniometer"] = 0;
+  expt_out["scan"] = 0;
+
+  // add the the actual models
+  elist_out["scan"] = std::array<json, 1>{_scan.to_json()};
+  elist_out["goniometer"] = std::array<json, 1>{_goniometer.to_json()};
+  elist_out["beam"] = std::array<json, 1>{_beam.to_json()};
+  elist_out["detector"] = std::array<json, 1>{_detector.to_json()};
+
+  if (_crystal.get_U_matrix().determinant()) {
+    expt_out["crystal"] = 0;
+    elist_out["crystal"] = std::array<json, 1>{_crystal.to_json()};
+  } else {
+    elist_out["crystal"] = std::array<json, 0>{};
   }
-  return *beam;
+
+  elist_out["experiment"] = std::array<json, 1>{expt_out};
+  return elist_out;
+}
+
+
+
+// factory function to make a typed experiment
+template<typename BeamType>
+TypedExperiment<BeamType> make_typed_experiment(json experiment_data){ // can add other types e.g. detector, scan
+  json beam_data = experiment_data["beam"][0];
+  std::shared_ptr<BeamBase> beamptr = make_beam(beam_data); // may raise std::runtime_error
+
+  // Make sure we can cast to the requested types.
+  BeamType* converted = dynamic_cast<BeamType*>(beamptr.get());
+  if (converted == nullptr){
+    throw std::runtime_error("Unable to make requested beam type");
+  }
+  json scan_data = experiment_data["scan"][0];
+  Scan scan(scan_data);
+  json gonio_data = experiment_data["goniometer"][0];
+  Goniometer gonio(gonio_data);
+  json detector_data = experiment_data["detector"][0];
+  Detector detector(detector_data);
+  return TypedExperiment<BeamType>(*converted, scan, gonio, detector);
 }
 
 #endif // DX2_MODEL_EXPERIMENT_H

--- a/include/dx2/experiment.h
+++ b/include/dx2/experiment.h
@@ -6,8 +6,8 @@
 #include <dx2/detector.h>
 #include <dx2/goniometer.h>
 #include <dx2/scan.h>
-#include <nlohmann/json.hpp>
 #include <memory>
+#include <nlohmann/json.hpp>
 using Eigen::Vector3d;
 using json = nlohmann::json;
 
@@ -30,7 +30,6 @@ protected:
   Detector _detector{};
   Crystal _crystal{};
 };
-
 
 Experiment::Experiment(json experiment_data) {
   json beam_data = experiment_data["beam"][0];
@@ -85,28 +84,16 @@ json Experiment::to_json() const {
   return elist_out;
 }
 
-Scan Experiment::scan() const {
-  return _scan;
-}
+Scan Experiment::scan() const { return _scan; }
 
-Goniometer Experiment::goniometer() const {
-  return _goniometer;
-}
+Goniometer Experiment::goniometer() const { return _goniometer; }
 
-Detector Experiment::detector() const {
-  return _detector;
-}
+Detector Experiment::detector() const { return _detector; }
 
-Crystal Experiment::crystal() const {
-  return _crystal;
-}
+Crystal Experiment::crystal() const { return _crystal; }
 
-void Experiment::set_crystal(Crystal crystal) {
-  _crystal = crystal;
-}
+void Experiment::set_crystal(Crystal crystal) { _crystal = crystal; }
 
-std::shared_ptr<BeamBase> Experiment::beam() const {
-  return _beam;
-}
+std::shared_ptr<BeamBase> Experiment::beam() const { return _beam; }
 
 #endif // DX2_MODEL_EXPERIMENT_H

--- a/include/dx2/experiment.h
+++ b/include/dx2/experiment.h
@@ -17,7 +17,8 @@ public:
   Experiment(json experiment_data);
   json to_json() const;
   Goniometer goniometer() const;
-  std::shared_ptr<BeamBase> beam() const;
+  template <typename BeamType>
+  BeamType& get_beam() const;
   Scan scan() const;
   Detector detector() const;
   Crystal crystal() const;
@@ -94,6 +95,14 @@ Crystal Experiment::crystal() const { return _crystal; }
 
 void Experiment::set_crystal(Crystal crystal) { _crystal = crystal; }
 
-std::shared_ptr<BeamBase> Experiment::beam() const { return _beam; }
+template <typename BeamType>
+BeamType& Experiment::get_beam() const {
+  BeamType* beam = dynamic_cast<BeamType*>(_beam.get());
+  if (beam == nullptr){
+    std::cerr << "Unable to return beam type " + std::string(typeid(BeamType).name()) + " (beam type is " + std::string(typeid(*_beam.get()).name())+ ")"<<std::endl;
+    std::exit(1);
+  }
+  return *beam;
+}
 
 #endif // DX2_MODEL_EXPERIMENT_H

--- a/include/dx2/experiment.h
+++ b/include/dx2/experiment.h
@@ -17,8 +17,7 @@ public:
   Experiment(json experiment_data);
   json to_json() const;
   Goniometer goniometer() const;
-  template <typename BeamType>
-  BeamType& get_beam() const;
+  template <typename BeamType> BeamType &get_beam() const;
   Scan scan() const;
   Detector detector() const;
   Crystal crystal() const;
@@ -95,11 +94,13 @@ Crystal Experiment::crystal() const { return _crystal; }
 
 void Experiment::set_crystal(Crystal crystal) { _crystal = crystal; }
 
-template <typename BeamType>
-BeamType& Experiment::get_beam() const {
-  BeamType* beam = dynamic_cast<BeamType*>(_beam.get());
-  if (beam == nullptr){
-    std::cerr << "Unable to return beam type " + std::string(typeid(BeamType).name()) + " (beam type is " + std::string(typeid(*_beam.get()).name())+ ")"<<std::endl;
+template <typename BeamType> BeamType &Experiment::get_beam() const {
+  BeamType *beam = dynamic_cast<BeamType *>(_beam.get());
+  if (beam == nullptr) {
+    std::cerr << "Unable to return beam type " +
+                     std::string(typeid(BeamType).name()) + " (beam type is " +
+                     std::string(typeid(*_beam.get()).name()) + ")"
+              << std::endl;
     std::exit(1);
   }
   return *beam;

--- a/include/dx2/experiment.h
+++ b/include/dx2/experiment.h
@@ -15,7 +15,8 @@ class Experiment {
 public:
   Experiment() = default;
   Experiment(json experiment_data);
-  Experiment(std::shared_ptr<BeamBase> beam, Scan scan, Goniometer gonio, Detector detector);
+  Experiment(std::shared_ptr<BeamBase> beam, Scan scan, Goniometer gonio,
+             Detector detector);
   json to_json() const;
   Goniometer goniometer() const;
   std::shared_ptr<BeamBase> beam() const;
@@ -32,15 +33,13 @@ protected:
   Crystal _crystal{};
 };
 
-Experiment::Experiment(std::shared_ptr<BeamBase> beam,
-                       Scan scan,
-                       Goniometer gonio,
-                       Detector detector){
-    this->_beam = beam;
-    this->_scan = scan;
-    this->_goniometer = gonio;
-    this->_detector = detector;
-  }
+Experiment::Experiment(std::shared_ptr<BeamBase> beam, Scan scan,
+                       Goniometer gonio, Detector detector) {
+  this->_beam = beam;
+  this->_scan = scan;
+  this->_goniometer = gonio;
+  this->_detector = detector;
+}
 
 Experiment::Experiment(json experiment_data) {
   json beam_data = experiment_data["beam"][0];
@@ -107,51 +106,61 @@ Crystal Experiment::crystal() const { return _crystal; }
 
 void Experiment::set_crystal(Crystal crystal) { _crystal = crystal; }
 
+template <typename BeamType> class TypedExperiment {
+public:
+  TypedExperiment(BeamType &beam, Scan scan, Goniometer gonio,
+                  Detector detector);
+  BeamType &get_beam() const;
+  Scan scan() const;
+  Detector detector() const;
+  Goniometer goniometer() const;
+  Crystal crystal() const;
+  void set_crystal(Crystal crystal);
+  json to_json() const;
 
-template<typename BeamType> class TypedExperiment {
-  public:
-    TypedExperiment(BeamType& beam, Scan scan, Goniometer gonio, Detector detector);
-    BeamType& get_beam() const;
-    Scan scan() const;
-    Detector detector() const;
-    Goniometer goniometer() const;
-    Crystal crystal() const;
-    void set_crystal(Crystal crystal);
-    json to_json() const;
-
-  private:
-    BeamType& _beam;
-    Scan _scan;
-    Goniometer _goniometer;
-    Detector _detector;
-    Crystal _crystal;
+private:
+  BeamType &_beam;
+  Scan _scan;
+  Goniometer _goniometer;
+  Detector _detector;
+  Crystal _crystal;
 };
 
-template<typename BeamType>
-TypedExperiment<BeamType>::TypedExperiment(BeamType& beam, Scan scan, Goniometer gonio, Detector detector) : _beam(beam), _scan(scan), _goniometer(gonio), _detector(detector){}
+template <typename BeamType>
+TypedExperiment<BeamType>::TypedExperiment(BeamType &beam, Scan scan,
+                                           Goniometer gonio, Detector detector)
+    : _beam(beam), _scan(scan), _goniometer(gonio), _detector(detector) {}
 
-template<typename BeamType>
-BeamType& TypedExperiment<BeamType>::get_beam() const {
+template <typename BeamType>
+BeamType &TypedExperiment<BeamType>::get_beam() const {
   return _beam;
 }
 
-template<typename BeamType>
-Scan TypedExperiment<BeamType>::scan() const { return _scan; }
+template <typename BeamType> Scan TypedExperiment<BeamType>::scan() const {
+  return _scan;
+}
 
-template<typename BeamType>
-Goniometer TypedExperiment<BeamType>::goniometer() const { return _goniometer; }
+template <typename BeamType>
+Goniometer TypedExperiment<BeamType>::goniometer() const {
+  return _goniometer;
+}
 
-template<typename BeamType>
-Detector TypedExperiment<BeamType>::detector() const { return _detector; }
+template <typename BeamType>
+Detector TypedExperiment<BeamType>::detector() const {
+  return _detector;
+}
 
-template<typename BeamType>
-Crystal TypedExperiment<BeamType>::crystal() const { return _crystal; }
+template <typename BeamType>
+Crystal TypedExperiment<BeamType>::crystal() const {
+  return _crystal;
+}
 
-template<typename BeamType>
-void TypedExperiment<BeamType>::set_crystal(Crystal crystal) { _crystal = crystal; }
+template <typename BeamType>
+void TypedExperiment<BeamType>::set_crystal(Crystal crystal) {
+  _crystal = crystal;
+}
 
-template<typename BeamType>
-json TypedExperiment<BeamType>::to_json() const {
+template <typename BeamType> json TypedExperiment<BeamType>::to_json() const {
   // save this experiment as an example experiment list
   json elist_out; // a list of potentially multiple experiments
   elist_out["__id__"] = "ExperimentList";
@@ -182,17 +191,17 @@ json TypedExperiment<BeamType>::to_json() const {
   return elist_out;
 }
 
-
-
 // factory function to make a typed experiment
-template<typename BeamType>
-TypedExperiment<BeamType> make_typed_experiment(json experiment_data){ // can add other types e.g. detector, scan
+template <typename BeamType>
+TypedExperiment<BeamType> make_typed_experiment(
+    json experiment_data) { // can add other types e.g. detector, scan
   json beam_data = experiment_data["beam"][0];
-  std::shared_ptr<BeamBase> beamptr = make_beam(beam_data); // may raise std::runtime_error
+  std::shared_ptr<BeamBase> beamptr =
+      make_beam(beam_data); // may raise std::runtime_error
 
   // Make sure we can cast to the requested types.
-  BeamType* converted = dynamic_cast<BeamType*>(beamptr.get());
-  if (converted == nullptr){
+  BeamType *converted = dynamic_cast<BeamType *>(beamptr.get());
+  if (converted == nullptr) {
     throw std::runtime_error("Unable to make requested beam type");
   }
   json scan_data = experiment_data["scan"][0];


### PR DESCRIPTION
After considering how to best to allow runtime polymorphism as part of model creation during serialization, I think we should not use templates in the experiment class, rather use shared pointers to a base class.
So far I have only implemented a beam class hierarchy, but I think we will need the same for scan, detector and perhaps others too (templating on all these would become cumbersome). The shared pointer is a similar approach to the existing dxtbx experiment code.

An example of how the usage changes in the indexer code is here: https://github.com/DiamondLightSource/fast-feedback-service/compare/main...dx2_used_shared_ptrs
This then allows dynamic creation at runtime, an in application code the correct type is checked after a dynamic_cast at the start of the program.
