### PR TITLE
Specialise ReflectionTable::add_column() for bools in full generality.

### DIFF
--- a/include/dx2/reflection.hpp
+++ b/include/dx2/reflection.hpp
@@ -781,16 +781,19 @@ public:
    * element).
    *
    * @param name The name of the column.
+   * @param shape A vector describing the shape of the column (e.g.,
+   * `{N}` for 1D, `{N, M}` for 2D).
    * @param column_data A vector of bools to convert and store as uint8_t.
    */
-  void add_column(const std::string &name,
-                  const std::vector<bool> &column_data) {
+  template<>
+  void add_column<bool>(const std::string &name, const std::vector<size_t> &shape,
+                        const std::vector<bool> &column_data) {
     std::vector<h5dispatch::BoolEnum> converted(column_data.size());
     for (size_t i = 0; i < column_data.size(); ++i) {
       converted[i] = column_data[i] ? h5dispatch::BoolEnum::TRUE
                                     : h5dispatch::BoolEnum::FALSE;
     }
-    add_column<h5dispatch::BoolEnum>(name, converted);
+    add_column<h5dispatch::BoolEnum>(name, shape, converted);
   }
 #pragma endregion
 

--- a/include/dx2/reflection.hpp
+++ b/include/dx2/reflection.hpp
@@ -773,29 +773,6 @@ public:
     add_column(name, std::vector<size_t>{rows, cols}, column_data);
   }
 
-  /**
-   * @brief Specialised overload to add a column from std::vector<bool>.
-   *
-   * std::vector<bool> does not provide `.data()` due to bit-packing, so
-   * this overload copies the data into a vector of uint8_t (1 byte per
-   * element).
-   *
-   * @param name The name of the column.
-   * @param shape A vector describing the shape of the column (e.g.,
-   * `{N}` for 1D, `{N, M}` for 2D).
-   * @param column_data A vector of bools to convert and store as uint8_t.
-   */
-  template <>
-  void add_column<bool>(const std::string &name,
-                        const std::vector<size_t> &shape,
-                        const std::vector<bool> &column_data) {
-    std::vector<h5dispatch::BoolEnum> converted(column_data.size());
-    for (size_t i = 0; i < column_data.size(); ++i) {
-      converted[i] = column_data[i] ? h5dispatch::BoolEnum::TRUE
-                                    : h5dispatch::BoolEnum::FALSE;
-    }
-    add_column<h5dispatch::BoolEnum>(name, shape, converted);
-  }
 #pragma endregion
 
 #pragma region Write
@@ -899,4 +876,28 @@ public:
   }
 #pragma endregion
 };
+
+  /**
+   * @brief Specialised overload to add a column from std::vector<bool>.
+   *
+   * std::vector<bool> does not provide `.data()` due to bit-packing, so
+   * this overload copies the data into a vector of uint8_t (1 byte per
+   * element).
+   *
+   * @param name The name of the column.
+   * @param shape A vector describing the shape of the column (e.g.,
+   * `{N}` for 1D, `{N, M}` for 2D).
+   * @param column_data A vector of bools to convert and store as uint8_t.
+   */
+  template<>
+  void ReflectionTable::add_column<bool>(const std::string &name, const std::vector<size_t> &shape,
+                        const std::vector<bool> &column_data) {
+    std::vector<h5dispatch::BoolEnum> converted(column_data.size());
+    for (size_t i = 0; i < column_data.size(); ++i) {
+      converted[i] = column_data[i] ? h5dispatch::BoolEnum::TRUE
+                                    : h5dispatch::BoolEnum::FALSE;
+    }
+    add_column<h5dispatch::BoolEnum>(name, shape, converted);
+  }
+
 #pragma endregion

--- a/include/dx2/reflection.hpp
+++ b/include/dx2/reflection.hpp
@@ -785,8 +785,9 @@ public:
    * `{N}` for 1D, `{N, M}` for 2D).
    * @param column_data A vector of bools to convert and store as uint8_t.
    */
-  template<>
-  void add_column<bool>(const std::string &name, const std::vector<size_t> &shape,
+  template <>
+  void add_column<bool>(const std::string &name,
+                        const std::vector<size_t> &shape,
                         const std::vector<bool> &column_data) {
     std::vector<h5dispatch::BoolEnum> converted(column_data.size());
     for (size_t i = 0; i < column_data.size(); ++i) {

--- a/include/dx2/reflection.hpp
+++ b/include/dx2/reflection.hpp
@@ -715,8 +715,7 @@ public:
                                       : h5dispatch::BoolEnum::FALSE;
       }
       add_column<h5dispatch::BoolEnum>(name, shape, converted);
-    }
-    else {
+    } else {
       auto col = std::make_unique<TypedColumn<T>>(name, shape, column_data);
 
       // Check for duplicate column names
@@ -729,9 +728,9 @@ public:
       // Check if type T is supported
       const auto &registry = h5dispatch::get_supported_types();
       bool supported = std::any_of(registry.begin(), registry.end(),
-                                  [](const h5dispatch::H5TypeInfo &info) {
-                                    return info.cpp_type == typeid(T);
-                                  });
+                                   [](const h5dispatch::H5TypeInfo &info) {
+                                     return info.cpp_type == typeid(T);
+                                   });
 
       if (!supported) {
         throw std::runtime_error(
@@ -742,7 +741,7 @@ public:
       // Ensure row count consistency
       if (!data.empty() && col->get_shape()[0] != get_row_count()) {
         throw std::runtime_error("Row count mismatch when adding column: " +
-                                name);
+                                 name);
       }
 
       // Add the new column to the table


### PR DESCRIPTION
I have modified the overload of `add_column()` intended for `bool`s so that the same syntax that works for other supported types works for `bool`s as well. Note that all downstream specialisations (eg. 1D input, row and col number as separate entries, etc.) follow naturally, using this specialisation as the base.

The motivation for this change was a need for consistency and clarity in syntax across types when inserting data into a reflection table in fast-feedback-service's prediction code.