### PR TITLE
Boundless panel intersection

### DIFF
--- a/dx2/detector.cxx
+++ b/dx2/detector.cxx
@@ -151,6 +151,17 @@ Panel::get_ray_intersection(const Vector3d &s1) const {
   return pxy; // in mm
 }
 
+std::optional<std::array<double, 2>>
+Panel::get_ray_intersection_unbounded(const Vector3d &s1) const {
+  // Project s₁ into panel frame: v = D·s₁
+  // v[2] is the depth component; reject rays travelling away from the panel
+  Vector3d v = D_ * s1;
+  if (v[2] <= 0) {
+    return {};
+  }
+  return std::array<double, 2>{v[0] / v[2], v[1] / v[2]}; // in mm, unbounded
+}
+
 std::array<double, 2> Panel::px_to_mm(double x, double y) const {
   double x1 = x * pixel_size_[0];
   double x2 = y * pixel_size_[1];

--- a/dx2/detector.cxx
+++ b/dx2/detector.cxx
@@ -148,7 +148,7 @@ Panel::get_ray_intersection(const Vector3d &s1) const {
       pxy[1] > image_size_mm_[1]) {
     return {};
   }
-  return pxy; // in mmm
+  return pxy; // in mm
 }
 
 std::array<double, 2> Panel::px_to_mm(double x, double y) const {

--- a/dx2/detector.cxx
+++ b/dx2/detector.cxx
@@ -135,23 +135,6 @@ Matrix3d Panel::get_d_matrix() const { return d_; }
 Matrix3d Panel::get_D_matrix() const { return D_; }
 
 std::optional<std::array<double, 2>>
-Panel::get_ray_intersection(const Vector3d &s1) const {
-  Vector3d v = D_ * s1;
-  if (v[2] <= 0) {
-    return {};
-  }
-  std::array<double, 2> pxy;
-  pxy[0] = v[0] / v[2];
-  pxy[1] = v[1] / v[2];
-  /** Check if the coordinate is invalid */
-  if (pxy[0] < 0 || pxy[1] < 0 || pxy[0] > image_size_mm_[0] ||
-      pxy[1] > image_size_mm_[1]) {
-    return {};
-  }
-  return pxy; // in mm
-}
-
-std::optional<std::array<double, 2>>
 Panel::get_ray_intersection_unbounded(const Vector3d &s1) const {
   // Project s₁ into panel frame: v = D·s₁
   // v[2] is the depth component; reject rays travelling away from the panel
@@ -160,6 +143,20 @@ Panel::get_ray_intersection_unbounded(const Vector3d &s1) const {
     return {};
   }
   return std::array<double, 2>{v[0] / v[2], v[1] / v[2]}; // in mm, unbounded
+}
+
+std::optional<std::array<double, 2>>
+Panel::get_ray_intersection(const Vector3d &s1) const {
+  // Use unbounded projection, then clip to the physical panel extent
+  auto pxy = get_ray_intersection_unbounded(s1);
+  if (!pxy) {
+    return {};
+  }
+  if ((*pxy)[0] < 0 || (*pxy)[1] < 0 || (*pxy)[0] > image_size_mm_[0] ||
+      (*pxy)[1] > image_size_mm_[1]) {
+    return {};
+  }
+  return pxy; // in mm
 }
 
 std::array<double, 2> Panel::px_to_mm(double x, double y) const {

--- a/include/dx2/detector.hpp
+++ b/include/dx2/detector.hpp
@@ -52,6 +52,8 @@ public:
   Vector3d get_lab_coord(double x_mm, double y_mm) const;
   std::optional<std::array<double, 2>>
   get_ray_intersection(const Vector3d &s1) const;
+  std::optional<std::array<double, 2>>
+  get_ray_intersection_unbounded(const Vector3d &s1) const;
   std::array<double, 2> get_pixel_size() const;
   json to_json() const;
   Vector3d get_origin() const;

--- a/include/dx2/utils.hpp
+++ b/include/dx2/utils.hpp
@@ -4,7 +4,7 @@
 
 using Eigen::Vector3d;
 
-double angle_between_vectors_degrees(Vector3d v1, Vector3d v2) {
+inline double angle_between_vectors_degrees(Vector3d v1, Vector3d v2) {
   double l1 = v1.norm();
   double l2 = v2.norm();
   double dot = v1.dot(v2);


### PR DESCRIPTION
`Panel::get_ray_intersection` checks whether the computed intersection
lies within the physical extent of the panel before returning a result.
This is correct for determining whether a reflection is genuinely
recorded, but is too restrictive when the intersection is needed
regardless of whether it falls within the detector boundary, like when
computing bounding boxes.

This PR adds a companion method that performs the same
ray-to-panel-frame projection but omits the bounds check, returning the
mm coordinate for any forward-facing ray.

- Add `Panel::get_ray_intersection_unbounded`, which projects s₁ into
  the panel frame via D·s₁ and returns the mm intersection for any ray
  with a positive depth component, without checking against
  `image_size_mm_`.
- Refactor `get_ray_intersection` to delegate to
  `get_ray_intersection_unbounded` and apply the bounds check on the
  result, eliminating duplicated projection arithmetic.
- Fix a typo in the return comment of `get_ray_intersection` (`mmm` →
  `mm`).

This allows callers that previously had to replicate the projection
arithmetic inline to use the Panel API directly, while preserving the
bounds-checked behaviour of the existing method for all current calls.