### PR TITLE
Return const references from member accessors

### DIFF
--- a/dx2/crystal.cxx
+++ b/dx2/crystal.cxx
@@ -101,9 +101,11 @@ void Crystal::set_A_matrix(Matrix3d A) {
   U_ = A_ * B_.inverse();
 }
 
-gemmi::UnitCell Crystal::get_unit_cell() const { return unit_cell_; }
+const gemmi::UnitCell &Crystal::get_unit_cell() const { return unit_cell_; }
 
-gemmi::SpaceGroup Crystal::get_space_group() const { return space_group_; }
+const gemmi::SpaceGroup &Crystal::get_space_group() const {
+  return space_group_;
+}
 
 Matrix3d Crystal::get_A_matrix() const { return A_; }
 

--- a/dx2/detector.cxx
+++ b/dx2/detector.cxx
@@ -312,7 +312,7 @@ json Detector::to_json() const {
   return detector_data;
 }
 
-std::vector<Panel> Detector::panels() const { return _panels; }
+const std::vector<Panel> &Detector::panels() const { return _panels; }
 
 void Detector::update(Matrix3d d) { _panels[0].update(d); }
 

--- a/dx2/imagesequence.cxx
+++ b/dx2/imagesequence.cxx
@@ -67,4 +67,4 @@ json ImageSequence::to_json() const {
   return imageset_data;
 }
 
-std::string ImageSequence::filename() const { return filename_; }
+const std::string &ImageSequence::filename() const { return filename_; }

--- a/include/dx2/crystal.hpp
+++ b/include/dx2/crystal.hpp
@@ -19,8 +19,8 @@ public:
   Crystal() = default;
   Crystal(Vector3d a, Vector3d b, Vector3d c, gemmi::SpaceGroup space_group);
   Crystal(json crystal_data);
-  gemmi::UnitCell get_unit_cell() const;
-  gemmi::SpaceGroup get_space_group() const;
+  const gemmi::UnitCell &get_unit_cell() const;
+  const gemmi::SpaceGroup &get_space_group() const;
   Matrix3d get_A_matrix() const;
   Matrix3d get_U_matrix() const;
   Matrix3d get_B_matrix() const;

--- a/include/dx2/detector.hpp
+++ b/include/dx2/detector.hpp
@@ -110,7 +110,7 @@ public:
   Detector(json detector_data);
   Detector(std::vector<Panel> panels);
   json to_json() const;
-  std::vector<Panel> panels() const;
+  const std::vector<Panel> &panels() const;
   std::optional<intersection> get_ray_intersection(const Vector3d &s1) const;
   void update(Matrix3d d);
 

--- a/include/dx2/imagesequence.hpp
+++ b/include/dx2/imagesequence.hpp
@@ -12,7 +12,7 @@ public:
       std::string filename); // Constructor for non-MultiImage formats e.g. cbf.
   ImageSequence(json imagesequence_data);
   json to_json() const;
-  std::string filename() const;
+  const std::string &filename() const;
 
 protected:
   int n_images_{};


### PR DESCRIPTION
This PR fixes `Detector::panels()` returning `std::vector<Panel>` by
value, which created dangling references for callers binding to
`panels()[0]` and deep-copied the heavy panel vector on every call. It
also audits the remaining DX2 accessors so we don't hit the same silent,
non-error-throwing issue elsewhere.

### Changes:

- Changes `Detector::panels()` (`include/dx2/detector.hpp`,
  `dx2/detector.cxx`) from `std::vector<Panel>` to `const
  std::vector<Panel> &`, the idiomatic accessor form. This removes both
  the dangling-reference issue and the per-call deep copy of every heavy
  `Panel`.
- Audits every accessor across `beam`, `crystal`, `goniometer`, `scan`,
  `experiment`, `imagesequence` and `reflection` for the same pattern.
  Three further member-backed accessors returned heap-owning types by
  value and are now const references:
  - `Crystal::get_unit_cell()` now returns `const gemmi::UnitCell &`
  - `Crystal::get_space_group()` now returns `const gemmi::SpaceGroup &`
  - `ImageSequence::filename()` now returns `const std::string &`
- Intentionally leaves the remaining accessors returning by value, with
  rationale:
  - Computed accessors (`Beam::get_s0()`, `Scan::get_oscillation()`,
    etc.) construct a new value and must return by value.
  - Small trivially-copyable value types returned from members (Eigen
    fixed-size `Matrix3d`/`Vector3d`, `std::array<…,2>`, `double`) are
    stack-only, cheap to copy, and carry no dangling-subobject risk in
    practice.
  - `ReflectionTable` vector accessors and
    `Experiment::identifier()`/`goniometer()` already use the
    const-reference form.
- No call sites in the repo or tests bound a reference to or mutated the
  return of the changed accessors, so there were no call-site changes.
  Existing `gemmi::UnitCell cell = crystal.get_unit_cell();` copies
  remain valid.

This removes a runtime-only, non-deterministic memory-corruption class
from the detector model and brings the rest of the DX2 accessors into a
consistent, audited state.

Closes #45.
